### PR TITLE
Add fallback for event listener in Media Query List

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,12 @@ export function setDark(isDark: boolean) {
 export function onUpdate(cb: (isDark: boolean) => void) {
   updateCallbacks.push(cb);
 
-  window.matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', () => cb(isDark()));
+  try {
+    window.matchMedia('(prefers-color-scheme: dark)')
+        .addEventListener('change', () => cb(isDark()));
+  } catch (e) {
+    // Fallback for Safari < 14 and older browsers
+    window.matchMedia('(prefers-color-scheme: dark)')
+        .addListener(() => cb(isDark()));
+  }
 }


### PR DESCRIPTION
The purpose of this PR is to fix the [bug with Safari < 14](https://bugs.webkit.org/show_bug.cgi?id=203288) using `addEventListener()` method in a `MediaQueryList` object.

The idea is to bring Safari < 14 support and backward compatibility using the [`addListener`](https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList#Methods) method as a fallback when `addEventListener` is not available to use.

This PR will fix this issue https://github.com/kazzkiq/darkmode/issues/3 and won't affect the current functionality.

Related info: https://github.com/mdn/sprints/issues/858